### PR TITLE
fix: lockedpool.cpp runtime_error

### DIFF
--- a/src/support/lockedpool.cpp
+++ b/src/support/lockedpool.cpp
@@ -26,6 +26,7 @@
 #include <sys/resource.h> // for getrlimit
 #include <limits.h> // for PAGESIZE
 #include <unistd.h> // for sysconf
+#include <stdexcept> // for std::runtime_error
 #endif
 
 #include <algorithm>


### PR DESCRIPTION
Fix compilation error (missing header file) on gcc version 13.2.0 See docs: https://en.cppreference.com/w/cpp/header/stdexcept

g++ error message:

 CXX      support/libsatoxcoin_util_a-lockedpool.o
support/lockedpool.cpp: In member function ‘void Arena::free(void*)’:
support/lockedpool.cpp:100:20: error: ‘runtime_error’ is not a member of ‘std’
  100 |         throw std::runtime_error("Arena: invalid or double free");
      |                    ^~~~~~~~~~~~~
support/lockedpool.cpp:32:1: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
   31 | #include <algorithm>
  +++ |+#include <stdexcept>