### PR TITLE
fix: bench.h uint64_t

### DIFF
--- a/src/bench/bench.h
+++ b/src/bench/bench.h
@@ -11,6 +11,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <cstdint>
 
 #include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/stringize.hpp>


### PR DESCRIPTION
Fix compilation error (missing header file) on gcc version 13.2.0

See https://en.cppreference.com/w/cpp/header/cstdint

g++ error  message:

In file included from bench/bench.cpp:7:
bench/bench.h:47:9: error: ‘uint64_t’ does not name a type
   47 |         uint64_t count;
      |         ^~~~~~~~
bench/bench.h:17:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   16 | #include <boost/preprocessor/stringize.hpp>
  +++ |+#include <cstdint>